### PR TITLE
make `versions` a property with getter

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,6 +59,12 @@ const process = Object.defineProperties(
     get version() {
       return lazy('version', require('cgjs/package.json').version);
     },
+    get versions() {
+      return lazy('versions', Object.assign(
+        {cgjs: process.version},
+        require('cgjs/package.json').dependencies
+      ));
+    },
 
     // methods
     abort() {
@@ -79,12 +85,6 @@ const process = Object.defineProperties(
     },
     uptime() {
       return (Date.now() - TIME) / 1000;
-    },
-    versions() {
-      return Object.assign(
-        {cgjs: process.version},
-        require('cgjs/package.json').dependencies
-      );
     }
   })
 );


### PR DESCRIPTION
Hi, I'm experimenting with building a shared interface with https://github.com/Place1/node-gir to run scripts both in Node.js and in gjs with cgjs. When I was trying to detect which environment I'm in, I noticed `versions` is a function in `@cgjs/process` while in Node.js and Electron it's an object.

- https://nodejs.org/api/process.html#process_process_versions
- https://electronjs.org/docs/api/process#processversionschrome